### PR TITLE
Changing the image of the vtc vnf in the 2VNF-1POP qualification test…

### DIFF
--- a/qual-2VNF-1PoP/sources/vnf/vtc-vnf/vtc-vnf-vnfd.yml
+++ b/qual-2VNF-1PoP/sources/vnf/vtc-vnf/vtc-vnf-vnfd.yml
@@ -9,7 +9,7 @@ description: >
 virtual_deployment_units:
   - id: "vdu01"
     description: "VNFC for the vTC"
-    vm_image: "eu.sonata-nfv_sonata-vtc_vdu01_qual"
+    vm_image: "eu.sonata-nfv_sonata-vring_vdu01"
     vm_image_format: "qcow2"
     resource_requirements:
       cpu:


### PR DESCRIPTION
…. Image is now, temporarily, also the vring image.